### PR TITLE
Fix to work without deprecation warning on Node v22+

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var Stat = require('fs').Stats
 module.exports = cloneStats
 
 function cloneStats(stats) {
-  var replacement = new Stat
+  var replacement = Object.create(Object.getPrototypeOf(stats))
 
   Object.keys(stats).forEach(function(key) {
     replacement[key] = stats[key]


### PR DESCRIPTION
Slightly cleaned up version of #2.  Also preserves original (important) test that the returned value passes `instance Stats` checks.